### PR TITLE
Pin helm ci version to 4.1.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
+        with:
+          version: v4.1.4
 
       - name: Parse Chart.yaml
         id: parse-chart

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
+        with:
+          version: v4.1.4
 
       - name: Run tests
         run: task install-plugins test


### PR DESCRIPTION
Helm V4.2 has two regressions that I want to avoid, so we're pinning to 4.1 until they've been fixed:
* https://github.com/helm/helm/issues/32163
* https://github.com/helm/helm/issues/32132